### PR TITLE
feat: add @typescript-eslint/no-unused-vars rule

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -57,6 +57,12 @@ module.exports = {
             tsx: 'never',
           },
         ],
+
+        // Prevent imported interface types from being treated as an unused import and enable
+        // the @typescript-eslint version
+        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': 'warn',
       },
     },
   ],


### PR DESCRIPTION
I was checking out @typescript-eslint and was looking for a TypeScript port of the Airbnb configuration, and discovered this repository, many thanks! 👏🏻

I discovered that when importing an interface from a module, `eslint` would complain it is an unused var. So I checked out what the recommended config for @typescript-eslint's `eslint-plugin` did (https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/src/configs/recommended.json#L32-L33).

I feel it would make a good addition to this plugin as the normal JavaScript rule is enabled in `eslint-config-airbnb-base` (https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/rules/variables.js#L39) so enabling the TypeScript "equivalent" makes sense.