### PR TITLE
Disable eslint rules that are incompatible with typescript

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,21 @@
+// This file adds some React specific settings. Not using React? Use base.js instead.
 module.exports = {
   extends: ['eslint-config-airbnb', './lib/shared'].map(require.resolve),
   overrides: [
     {
       files: ['*.ts', '*.tsx'],
       settings: {
+        // Append 'ts' and 'tsx' extensions to Airbnb 'import/resolver' setting
         'import/resolver': {
           node: {
             extensions: ['.js', '.ts', '.jsx', '.tsx', '.json'],
           },
         },
+        // Append 'ts' and 'tsx' extensions to Airbnb 'import/extensions' setting
         'import/extensions': ['.js', '.ts', '.mjs', '.jsx', '.tsx'],
       },
       rules: {
-        // only .jsx and .tsx files may have JSX
+        // Append 'tsx' to Airbnb 'react/jsx-filename-extension' rule
         // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md
         'react/jsx-filename-extension': [
           'error',

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -5,17 +5,83 @@ module.exports = {
       parser: '@typescript-eslint/parser',
       plugins: ['@typescript-eslint'],
       settings: {
+        // Append 'ts' extensions to Airbnb 'import/resolver' setting
         'import/resolver': {
           node: {
             extensions: ['.mjs', '.js', '.ts', '.json'],
           },
         },
+        // Append 'ts' extensions to Airbnb 'import/extensions' setting
         'import/extensions': ['.js', '.ts', '.mjs'],
       },
       rules: {
+        // Replace Airbnb 'camelcase' rule with '@typescript-eslint' version
+        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/camelcase.md
+        camelcase: 'off',
+        '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
+
+        // Replace Airbnb 'indent' rule with '@typescript-indent' version
+        indent: 'off',
+        '@typescript-eslint/indent': [
+          'error',
+          2,
+          {
+            SwitchCase: 1,
+            VariableDeclarator: 1,
+            outerIIFEBody: 1,
+            // MemberExpression: null,
+            FunctionDeclaration: {
+              parameters: 1,
+              body: 1,
+            },
+            FunctionExpression: {
+              parameters: 1,
+              body: 1,
+            },
+            CallExpression: {
+              arguments: 1,
+            },
+            ArrayExpression: 1,
+            ObjectExpression: 1,
+            ImportDeclaration: 1,
+            flatTernaryExpressions: false,
+            // list derived from https://github.com/benjamn/ast-types/blob/HEAD/def/jsx.js
+            ignoredNodes: [
+              'JSXElement',
+              'JSXElement > *',
+              'JSXAttribute',
+              'JSXIdentifier',
+              'JSXNamespacedName',
+              'JSXMemberExpression',
+              'JSXSpreadAttribute',
+              'JSXExpressionContainer',
+              'JSXOpeningElement',
+              'JSXClosingElement',
+              'JSXText',
+              'JSXEmptyExpression',
+              'JSXSpreadChild',
+            ],
+            ignoreComments: false,
+          },
+        ],
+
+        // Replace Airbnb 'no-array-constructor' rule with '@typescript-eslint' version
+        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-array-constructor.md
+        'no-array-constructor': 'off',
+        '@typescript-eslint/no-array-constructor': 'error',
+
+        // Replace Airbnb 'no-unused-vars' rule with '@typescript-eslint' version
+        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          { vars: 'all', args: 'after-used', ignoreRestSiblings: true },
+        ],
+
+        // Append `ts` and `tsx` extensions to Airbnb 'import/no-extraneous-dependencies' rule
         // Forbid the use of extraneous packages
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
-        // paths are treated both as absolute paths, and relative to process.cwd()
+        // Paths are treated both as absolute paths, and relative to process.cwd()
         'import/no-extraneous-dependencies': [
           'error',
           {
@@ -44,6 +110,7 @@ module.exports = {
           },
         ],
 
+        // Append `ts` and `tsx` to Airbnb 'import/extensions' rule
         // Ensure consistent use of file extension within the import path
         // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
         'import/extensions': [
@@ -57,12 +124,6 @@ module.exports = {
             tsx: 'never',
           },
         ],
-
-        // Prevent imported interface types from being treated as an unused import and enable
-        // the @typescript-eslint version
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
-        'no-unused-vars': 'off',
-        '@typescript-eslint/no-unused-vars': 'warn',
       },
     },
   ],


### PR DESCRIPTION
These rules are now replaced with equivalent 'typescript-eslint' rules.

BREAKING CHANGE: Config may find additional linting errors for: `camelcase`, `indent`, `no-array-constructor`, and `no-unused-vars`.

Thanks to @tombell for raising this original issue in #3  👏 
