### PR TITLE
Lint both JS and TS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Use this when you're trying to mix [eslint-config-airbnb](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb) with [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint).
 
+Note: this config works for both JS and TS files.
+
 ## I use eslint-config-airbnb (with React support)
 
 Install dependencies. ESLint plugins [must also be installed](https://github.com/eslint/eslint/issues/10125).

--- a/index.js
+++ b/index.js
@@ -1,27 +1,19 @@
 // This file adds some React specific settings. Not using React? Use base.js instead.
 module.exports = {
   extends: ['eslint-config-airbnb', './lib/shared'].map(require.resolve),
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx'],
-      settings: {
-        // Append 'ts' and 'tsx' extensions to Airbnb 'import/resolver' setting
-        'import/resolver': {
-          node: {
-            extensions: ['.js', '.ts', '.jsx', '.tsx', '.json'],
-          },
-        },
-        // Append 'ts' and 'tsx' extensions to Airbnb 'import/extensions' setting
-        'import/extensions': ['.js', '.ts', '.mjs', '.jsx', '.tsx'],
-      },
-      rules: {
-        // Append 'tsx' to Airbnb 'react/jsx-filename-extension' rule
-        // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md
-        'react/jsx-filename-extension': [
-          'error',
-          { extensions: ['.jsx', '.tsx'] },
-        ],
+  settings: {
+    // Append 'ts' and 'tsx' extensions to Airbnb 'import/resolver' setting
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.ts', '.jsx', '.tsx', '.json'],
       },
     },
-  ],
+    // Append 'ts' and 'tsx' extensions to Airbnb 'import/extensions' setting
+    'import/extensions': ['.js', '.ts', '.mjs', '.jsx', '.tsx'],
+  },
+  rules: {
+    // Append 'tsx' to Airbnb 'react/jsx-filename-extension' rule
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-filename-extension.md
+    'react/jsx-filename-extension': ['error', { extensions: ['.jsx', '.tsx'] }],
+  },
 };

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -1,130 +1,125 @@
 module.exports = {
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx'],
-      parser: '@typescript-eslint/parser',
-      plugins: ['@typescript-eslint'],
-      settings: {
-        // Append 'ts' extensions to Airbnb 'import/resolver' setting
-        'import/resolver': {
-          node: {
-            extensions: ['.mjs', '.js', '.ts', '.json'],
-          },
-        },
-        // Append 'ts' extensions to Airbnb 'import/extensions' setting
-        'import/extensions': ['.js', '.ts', '.mjs'],
-      },
-      rules: {
-        // Replace Airbnb 'camelcase' rule with '@typescript-eslint' version
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/camelcase.md
-        camelcase: 'off',
-        '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
-
-        // Replace Airbnb 'indent' rule with '@typescript-indent' version
-        indent: 'off',
-        '@typescript-eslint/indent': [
-          'error',
-          2,
-          {
-            SwitchCase: 1,
-            VariableDeclarator: 1,
-            outerIIFEBody: 1,
-            // MemberExpression: null,
-            FunctionDeclaration: {
-              parameters: 1,
-              body: 1,
-            },
-            FunctionExpression: {
-              parameters: 1,
-              body: 1,
-            },
-            CallExpression: {
-              arguments: 1,
-            },
-            ArrayExpression: 1,
-            ObjectExpression: 1,
-            ImportDeclaration: 1,
-            flatTernaryExpressions: false,
-            // list derived from https://github.com/benjamn/ast-types/blob/HEAD/def/jsx.js
-            ignoredNodes: [
-              'JSXElement',
-              'JSXElement > *',
-              'JSXAttribute',
-              'JSXIdentifier',
-              'JSXNamespacedName',
-              'JSXMemberExpression',
-              'JSXSpreadAttribute',
-              'JSXExpressionContainer',
-              'JSXOpeningElement',
-              'JSXClosingElement',
-              'JSXText',
-              'JSXEmptyExpression',
-              'JSXSpreadChild',
-            ],
-            ignoreComments: false,
-          },
-        ],
-
-        // Replace Airbnb 'no-array-constructor' rule with '@typescript-eslint' version
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-array-constructor.md
-        'no-array-constructor': 'off',
-        '@typescript-eslint/no-array-constructor': 'error',
-
-        // Replace Airbnb 'no-unused-vars' rule with '@typescript-eslint' version
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
-        'no-unused-vars': 'off',
-        '@typescript-eslint/no-unused-vars': [
-          'error',
-          { vars: 'all', args: 'after-used', ignoreRestSiblings: true },
-        ],
-
-        // Append `ts` and `tsx` extensions to Airbnb 'import/no-extraneous-dependencies' rule
-        // Forbid the use of extraneous packages
-        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
-        // Paths are treated both as absolute paths, and relative to process.cwd()
-        'import/no-extraneous-dependencies': [
-          'error',
-          {
-            devDependencies: [
-              'test/**', // tape, common npm pattern
-              'tests/**', // also common npm pattern
-              'spec/**', // mocha, rspec-like pattern
-              '**/__tests__/**', // jest pattern
-              '**/__mocks__/**', // jest pattern
-              'test.{js,jsx,ts,tsx}', // repos with a single test file
-              'test-*.{js,jsx,ts,tsx}', // repos with multiple top-level test files
-              '**/*{.,_}{test,spec}.{js,jsx,ts,tsx}', // tests where the extension or filename suffix denotes that it is a test
-              '**/jest.config.js', // jest config
-              '**/vue.config.js', // vue-cli config
-              '**/webpack.config.js', // webpack config
-              '**/webpack.config.*.js', // webpack config
-              '**/rollup.config.js', // rollup config
-              '**/rollup.config.*.js', // rollup config
-              '**/gulpfile.js', // gulp config
-              '**/gulpfile.*.js', // gulp config
-              '**/Gruntfile{,.js}', // grunt config
-              '**/protractor.conf.js', // protractor config
-              '**/protractor.conf.*.js', // protractor config
-            ],
-            optionalDependencies: false,
-          },
-        ],
-
-        // Append `ts` and `tsx` to Airbnb 'import/extensions' rule
-        // Ensure consistent use of file extension within the import path
-        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
-        'import/extensions': [
-          'error',
-          'ignorePackages',
-          {
-            js: 'never',
-            mjs: 'never',
-            jsx: 'never',
-            ts: 'never',
-            tsx: 'never',
-          },
-        ],
+  plugins: ['@typescript-eslint'],
+  parser: '@typescript-eslint/parser',
+  settings: {
+    // Append 'ts' extensions to Airbnb 'import/resolver' setting
+    'import/resolver': {
+      node: {
+        extensions: ['.mjs', '.js', '.ts', '.json'],
       },
     },
-  ],
+    // Append 'ts' extensions to Airbnb 'import/extensions' setting
+    'import/extensions': ['.js', '.ts', '.mjs'],
+  },
+  rules: {
+    // Replace Airbnb 'camelcase' rule with '@typescript-eslint' version
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/camelcase.md
+    camelcase: 'off',
+    '@typescript-eslint/camelcase': ['error', { properties: 'never' }],
+
+    // Replace Airbnb 'indent' rule with '@typescript-indent' version
+    indent: 'off',
+    '@typescript-eslint/indent': [
+      'error',
+      2,
+      {
+        SwitchCase: 1,
+        VariableDeclarator: 1,
+        outerIIFEBody: 1,
+        // MemberExpression: null,
+        FunctionDeclaration: {
+          parameters: 1,
+          body: 1,
+        },
+        FunctionExpression: {
+          parameters: 1,
+          body: 1,
+        },
+        CallExpression: {
+          arguments: 1,
+        },
+        ArrayExpression: 1,
+        ObjectExpression: 1,
+        ImportDeclaration: 1,
+        flatTernaryExpressions: false,
+        // list derived from https://github.com/benjamn/ast-types/blob/HEAD/def/jsx.js
+        ignoredNodes: [
+          'JSXElement',
+          'JSXElement > *',
+          'JSXAttribute',
+          'JSXIdentifier',
+          'JSXNamespacedName',
+          'JSXMemberExpression',
+          'JSXSpreadAttribute',
+          'JSXExpressionContainer',
+          'JSXOpeningElement',
+          'JSXClosingElement',
+          'JSXText',
+          'JSXEmptyExpression',
+          'JSXSpreadChild',
+        ],
+        ignoreComments: false,
+      },
+    ],
+
+    // Replace Airbnb 'no-array-constructor' rule with '@typescript-eslint' version
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-array-constructor.md
+    'no-array-constructor': 'off',
+    '@typescript-eslint/no-array-constructor': 'error',
+
+    // Replace Airbnb 'no-unused-vars' rule with '@typescript-eslint' version
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      { vars: 'all', args: 'after-used', ignoreRestSiblings: true },
+    ],
+
+    // Append `ts` and `tsx` extensions to Airbnb 'import/no-extraneous-dependencies' rule
+    // Forbid the use of extraneous packages
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
+    // Paths are treated both as absolute paths, and relative to process.cwd()
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        devDependencies: [
+          'test/**', // tape, common npm pattern
+          'tests/**', // also common npm pattern
+          'spec/**', // mocha, rspec-like pattern
+          '**/__tests__/**', // jest pattern
+          '**/__mocks__/**', // jest pattern
+          'test.{js,jsx,ts,tsx}', // repos with a single test file
+          'test-*.{js,jsx,ts,tsx}', // repos with multiple top-level test files
+          '**/*{.,_}{test,spec}.{js,jsx,ts,tsx}', // tests where the extension or filename suffix denotes that it is a test
+          '**/jest.config.js', // jest config
+          '**/vue.config.js', // vue-cli config
+          '**/webpack.config.js', // webpack config
+          '**/webpack.config.*.js', // webpack config
+          '**/rollup.config.js', // rollup config
+          '**/rollup.config.*.js', // rollup config
+          '**/gulpfile.js', // gulp config
+          '**/gulpfile.*.js', // gulp config
+          '**/Gruntfile{,.js}', // grunt config
+          '**/protractor.conf.js', // protractor config
+          '**/protractor.conf.*.js', // protractor config
+        ],
+        optionalDependencies: false,
+      },
+    ],
+
+    // Append `ts` and `tsx` to Airbnb 'import/extensions' rule
+    // Ensure consistent use of file extension within the import path
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      {
+        js: 'never',
+        mjs: 'never',
+        jsx: 'never',
+        ts: 'never',
+        tsx: 'never',
+      },
+    ],
+  },
 };


### PR DESCRIPTION
We are currently applying the linting settings and rules to TS files only. However, this is *not* necessary, as the same config works on both JS and TS files.

The current config also makes overriding rules more difficult, as reported by @dawidk92 in #4.

This PR makes the linting rules and settings more generic, and will lint all files passed into ESLint (JS and/or TS files).