### PR TITLE
Remove arrow-parens rule override

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -14,7 +14,7 @@ module.exports = {
   rules: {
     "arrow-parens": [
       "error",
-      "as-needed",
+      "always",
       {
         // `requireForBlockBody` should be `true` (as Airbnb sets this to `true`), however it causes problems with HOC syntax in TS
         // https://github.com/iamturns/eslint-config-airbnb-typescript/issues/8

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -12,16 +12,6 @@ module.exports = {
     "import/extensions": [".js", ".ts", ".mjs"],
   },
   rules: {
-    "arrow-parens": [
-      "error",
-      "always",
-      {
-        // `requireForBlockBody` should be `true` (as Airbnb sets this to `true`), however it causes problems with HOC syntax in TS
-        // https://github.com/iamturns/eslint-config-airbnb-typescript/issues/8
-        requireForBlockBody: false,
-      },
-    ],
-
     // Replace Airbnb 'brace-style' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/brace-style.md
     "brace-style": "off",


### PR DESCRIPTION
Fixes https://github.com/iamturns/eslint-config-airbnb-typescript/issues/19