### PR TITLE
Disable `no-undef` rule

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -122,6 +122,9 @@ module.exports = {
         detectObjects: false,
       },
     ],
+    
+    // Disable Airbnb 'no-undef' rule as it's recommended to do so in TypeScript projects
+    "no-undef": "off",
 
     // Replace Airbnb 'no-unused-vars' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md


### PR DESCRIPTION
As per [this comment](https://github.com/typescript-eslint/typescript-eslint/issues/662#issuecomment-507081586) it's recommended to turn off the `no-undef` rule for TypeScript projects.