### PR TITLE
Extend base config rules directly

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -123,11 +123,8 @@ module.exports = {
         ...baseImportsRules["import/no-extraneous-dependencies"][1],
         devDependencies: baseImportsRules[
           "import/no-extraneous-dependencies"
-        ][1].devDependencies.map(
-          glob =>
-            glob
-              .replace(/\.(jsx?)$/, ".{$1}") // Wrap file extensions in braces
-              .replace(/((\.*)js(x?))/g, "$1,$2ts$3"), // 'jsx?' => 'jsx?,tsx?'
+        ][1].devDependencies.map(glob =>
+          glob.replace("js,jsx", "js,jsx,ts,tsx"),
         ),
       },
     ],

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -84,13 +84,8 @@ module.exports = {
     // Replace Airbnb 'no-use-before-define' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md
     "no-use-before-define": "off",
-    "@typescript-eslint/no-use-before-define": [
-      baseVariablesRules["no-use-before-define"][0],
-      {
-        ...baseVariablesRules["no-use-before-define"][1],
-        typedefs: true,
-      },
-    ],
+    "@typescript-eslint/no-use-before-define":
+      baseVariablesRules["no-use-before-define"],
 
     // Replace Airbnb 'no-useless-constructor' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-useless-constructor.md

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -1,3 +1,20 @@
+const {
+  rules: baseBestPracticesRules,
+} = require("eslint-config-airbnb-base/rules/best-practices");
+const {
+  rules: baseErrorsRules,
+} = require("eslint-config-airbnb-base/rules/errors");
+const { rules: baseES6Rules } = require("eslint-config-airbnb-base/rules/es6");
+const {
+  rules: baseImportsRules,
+} = require("eslint-config-airbnb-base/rules/imports");
+const {
+  rules: baseStyleRules,
+} = require("eslint-config-airbnb-base/rules/style");
+const {
+  rules: baseVariablesRules,
+} = require("eslint-config-airbnb-base/rules/variables");
+
 module.exports = {
   plugins: ["@typescript-eslint"],
   parser: "@typescript-eslint/parser",
@@ -15,147 +32,77 @@ module.exports = {
     // Replace Airbnb 'brace-style' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/brace-style.md
     "brace-style": "off",
-    "@typescript-eslint/brace-style": [
-      "error",
-      "1tbs",
-      { allowSingleLine: true },
-    ],
+    "@typescript-eslint/brace-style": baseStyleRules["brace-style"],
 
     // Replace Airbnb 'camelcase' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/camelcase.md
     camelcase: "off",
-    "@typescript-eslint/camelcase": [
-      "error",
-      { properties: "never", ignoreDestructuring: false },
-    ],
+    "@typescript-eslint/camelcase": baseStyleRules.camelcase,
 
     // Replace Airbnb 'func-call-spacing' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/func-call-spacing.md
     "func-call-spacing": "off",
-    "@typescript-eslint/func-call-spacing": ["error", "never"],
+    "@typescript-eslint/func-call-spacing": baseStyleRules["func-call-spacing"],
 
     // Replace Airbnb 'indent' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/indent.md
     indent: "off",
-    "@typescript-eslint/indent": [
-      "error",
-      2,
-      {
-        SwitchCase: 1,
-        VariableDeclarator: 1,
-        outerIIFEBody: 1,
-        // MemberExpression: null,
-        FunctionDeclaration: {
-          parameters: 1,
-          body: 1,
-        },
-        FunctionExpression: {
-          parameters: 1,
-          body: 1,
-        },
-        CallExpression: {
-          arguments: 1,
-        },
-        ArrayExpression: 1,
-        ObjectExpression: 1,
-        ImportDeclaration: 1,
-        flatTernaryExpressions: false,
-        // list derived from https://github.com/benjamn/ast-types/blob/HEAD/def/jsx.js
-        ignoredNodes: [
-          "JSXElement",
-          "JSXElement > *",
-          "JSXAttribute",
-          "JSXIdentifier",
-          "JSXNamespacedName",
-          "JSXMemberExpression",
-          "JSXSpreadAttribute",
-          "JSXExpressionContainer",
-          "JSXOpeningElement",
-          "JSXClosingElement",
-          "JSXText",
-          "JSXEmptyExpression",
-          "JSXSpreadChild",
-        ],
-        ignoreComments: false,
-      },
-    ],
+    "@typescript-eslint/indent": baseStyleRules.indent,
 
     // Replace Airbnb 'no-array-constructor' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-array-constructor.md
     "no-array-constructor": "off",
-    "@typescript-eslint/no-array-constructor": "error",
+    "@typescript-eslint/no-array-constructor":
+      baseStyleRules["no-array-constructor"],
 
     // Replace Airbnb 'no-empty-function' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-empty-function.md
     "no-empty-function": "off",
-    "@typescript-eslint/no-empty-function": [
-      "error",
-      {
-        allow: ["arrowFunctions", "functions", "methods"],
-      },
-    ],
+    "@typescript-eslint/no-empty-function":
+      baseBestPracticesRules["no-empty-function"],
 
     // Replace Airbnb 'no-extra-parens' rule with '@typescript-indent' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-extra-parens.md
     "no-extra-parens": "off",
-    "@typescript-eslint/no-extra-parens": [
-      "off",
-      "all",
-      {
-        conditionalAssign: true,
-        nestedBinaryExpressions: false,
-        returnAssign: false,
-        ignoreJSX: "all", // delegate to eslint-plugin-react
-        enforceForArrowConditionals: false,
-      },
-    ],
+    "@typescript-eslint/no-extra-parens": baseErrorsRules["no-extra-parens"],
 
     // Replace Airbnb 'no-magic-numbers' rule with '@typescript-indent' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-magic-numbers.md
     "no-magic-numbers": "off",
-    "@typescript-eslint/no-magic-numbers": [
-      "off",
-      {
-        ignore: [],
-        ignoreArrayIndexes: true,
-        enforceConst: true,
-        detectObjects: false,
-      },
-    ],
+    "@typescript-eslint/no-magic-numbers":
+      baseBestPracticesRules["no-magic-numbers"],
 
     // Replace Airbnb 'no-unused-vars' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      { vars: "all", args: "after-used", ignoreRestSiblings: true },
-    ],
+    "@typescript-eslint/no-unused-vars": baseVariablesRules["no-unused-vars"],
 
     // Replace Airbnb 'no-use-before-define' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-use-before-define.md
     "no-use-before-define": "off",
     "@typescript-eslint/no-use-before-define": [
-      "error",
-      { functions: true, classes: true, variables: true },
+      baseVariablesRules["no-use-before-define"][0],
+      {
+        ...baseVariablesRules["no-use-before-define"][1],
+        typedefs: true,
+      },
     ],
 
     // Replace Airbnb 'no-useless-constructor' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-useless-constructor.md
     "no-useless-constructor": "off",
-    "@typescript-eslint/no-useless-constructor": "error",
+    "@typescript-eslint/no-useless-constructor":
+      baseES6Rules["no-useless-constructor"],
 
     // Replace Airbnb 'quotes' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/quotes.md
-    "quotes": "off",
-    "@typescript-eslint/quotes": [
-      "error",
-      "single", { avoidEscape: true }
-    ],
+    quotes: "off",
+    "@typescript-eslint/quotes": baseStyleRules.quotes,
 
     // Replace Airbnb 'semi' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/semi.md
     semi: "off",
-    "@typescript-eslint/semi": ["error", "always"],
+    "@typescript-eslint/semi": baseStyleRules.semi,
 
     // Append `ts` and `tsx` to Airbnb 'import/extensions' rule
     // Ensure consistent use of file extension within the import path
@@ -172,35 +119,20 @@ module.exports = {
       },
     ],
 
-    // Append `ts` and `tsx` extensions to Airbnb 'import/no-extraneous-dependencies' rule
-    // Forbid the use of extraneous packages
+    // Append 'ts' and 'tsx' extensions to Airbnb 'import/no-extraneous-dependencies' rule
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-extraneous-dependencies.md
-    // Paths are treated both as absolute paths, and relative to process.cwd()
     "import/no-extraneous-dependencies": [
-      "error",
+      baseImportsRules["import/no-extraneous-dependencies"][0],
       {
-        devDependencies: [
-          "test/**", // tape, common npm pattern
-          "tests/**", // also common npm pattern
-          "spec/**", // mocha, rspec-like pattern
-          "**/__tests__/**", // jest pattern
-          "**/__mocks__/**", // jest pattern
-          "test.{js,jsx,ts,tsx}", // repos with a single test file
-          "test-*.{js,jsx,ts,tsx}", // repos with multiple top-level test files
-          "**/*{.,_}{test,spec}.{js,jsx,ts,tsx}", // tests where the extension or filename suffix denotes that it is a test
-          "**/jest.config.js", // jest config
-          "**/vue.config.js", // vue-cli config
-          "**/webpack.config.js", // webpack config
-          "**/webpack.config.*.js", // webpack config
-          "**/rollup.config.js", // rollup config
-          "**/rollup.config.*.js", // rollup config
-          "**/gulpfile.js", // gulp config
-          "**/gulpfile.*.js", // gulp config
-          "**/Gruntfile{,.js}", // grunt config
-          "**/protractor.conf.js", // protractor config
-          "**/protractor.conf.*.js", // protractor config
-        ],
-        optionalDependencies: false,
+        ...baseImportsRules["import/no-extraneous-dependencies"][1],
+        devDependencies: baseImportsRules[
+          "import/no-extraneous-dependencies"
+        ][1].devDependencies.map(
+          glob =>
+            glob
+              .replace(/\.(jsx?)$/, ".{$1}") // Wrap file extensions in braces
+              .replace(/((\.*)js(x?))/g, "$1,$2ts$3"), // 'jsx?' => 'jsx?,tsx?'
+        ),
       },
     ],
   },

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -1,19 +1,19 @@
 const {
   rules: baseBestPracticesRules,
-} = require("eslint-config-airbnb-base/rules/best-practices");
+} = require("eslint-config-airbnb-base/rules/best-practices")
 const {
   rules: baseErrorsRules,
-} = require("eslint-config-airbnb-base/rules/errors");
-const { rules: baseES6Rules } = require("eslint-config-airbnb-base/rules/es6");
+} = require("eslint-config-airbnb-base/rules/errors")
+const { rules: baseES6Rules } = require("eslint-config-airbnb-base/rules/es6")
 const {
   rules: baseImportsRules,
-} = require("eslint-config-airbnb-base/rules/imports");
+} = require("eslint-config-airbnb-base/rules/imports")
 const {
   rules: baseStyleRules,
-} = require("eslint-config-airbnb-base/rules/style");
+} = require("eslint-config-airbnb-base/rules/style")
 const {
   rules: baseVariablesRules,
-} = require("eslint-config-airbnb-base/rules/variables");
+} = require("eslint-config-airbnb-base/rules/variables")
 
 module.exports = {
   plugins: ["@typescript-eslint"],

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -104,16 +104,13 @@ module.exports = {
     semi: "off",
     "@typescript-eslint/semi": baseStyleRules.semi,
 
-    // Append `ts` and `tsx` to Airbnb 'import/extensions' rule
-    // Ensure consistent use of file extension within the import path
+    // Append 'ts' and 'tsx' to Airbnb 'import/extensions' rule
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
     "import/extensions": [
-      "error",
-      "ignorePackages",
+      baseImportsRules["import/extensions"][0],
+      baseImportsRules["import/extensions"][1],
       {
-        js: "never",
-        mjs: "never",
-        jsx: "never",
+        ...baseImportsRules["import/extensions"][2],
         ts: "never",
         tsx: "never",
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format": "run-s format:package format:prettier format:eslint",
     "format:eslint": "eslint --cache --fix ./ >/dev/null 2>&1 || true",
     "format:package": "prettier-package-json --write",
-    "format:prettier": "prettier --write '**/*.{js,json,md,yml}' '.editorconfig' 'LICENSE'",
+    "format:prettier": "prettier --write \"**/*.{js,json,md,yml}\" \".editorconfig\" \"LICENSE\"",
     "lint": "eslint --cache ./",
     "validate": "npm run lint"
   },


### PR DESCRIPTION
In order to improve the maintainability of the package, direct imports should be applied instead of copying rules.