### PR TITLE
Add support for optional chaining

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -65,16 +65,22 @@ module.exports = {
     "@typescript-eslint/no-empty-function":
       baseBestPracticesRules["no-empty-function"],
 
-    // Replace Airbnb 'no-extra-parens' rule with '@typescript-indent' version
+    // Replace Airbnb 'no-extra-parens' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-extra-parens.md
     "no-extra-parens": "off",
     "@typescript-eslint/no-extra-parens": baseErrorsRules["no-extra-parens"],
 
-    // Replace Airbnb 'no-magic-numbers' rule with '@typescript-indent' version
+    // Replace Airbnb 'no-magic-numbers' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-magic-numbers.md
     "no-magic-numbers": "off",
     "@typescript-eslint/no-magic-numbers":
       baseBestPracticesRules["no-magic-numbers"],
+
+    // Replace Airbnb 'no-unused-expressions' rule with '@typescript-eslint' version
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-expressions.md
+    "no-unused-expressions": "off",
+    "@typescript-eslint/no-unused-expressions":
+      baseBestPracticesRules["no-unused-expressions"],
 
     // Replace Airbnb 'no-unused-vars' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-unused-vars.md


### PR DESCRIPTION
By replacing 'no-unused-expressions' with its '@typescript-eslint' equivalent.