### PR TITLE
Fix incorrect `no-undef` errors when exporting default interfaces

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -117,4 +117,15 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      rules: {
+        // Disable `no-undef` rule within TypeScript files because it incorrectly errors when exporting default interfaces
+        // https://github.com/iamturns/eslint-config-airbnb-typescript/issues/50
+        // This will be caught by TypeScript compiler if `strictNullChecks` (or `strict`) is enabled
+        'no-undef': 'off',
+      },
+    },
+  ],
 };


### PR DESCRIPTION
Fixes #50 
