### PR TITLE
Fix `no-dupe-class-members` error when overloading methods

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -125,6 +125,11 @@ module.exports = {
         // https://github.com/iamturns/eslint-config-airbnb-typescript/issues/50
         // This will be caught by TypeScript compiler if `strictNullChecks` (or `strict`) is enabled
         'no-undef': 'off',
+
+        // Disable `no-dupe-class-members` rule within TypeScript files beause it incorrectly errors when overloading methods
+        // https://github.com/iamturns/eslint-config-airbnb-typescript/issues/61
+        // Duplicate identifiers will be caught by TypeScript compiler
+        'no-dupe-class-members': 'off',
       },
     },
   ],


### PR DESCRIPTION
Fixes #61 