### PR TITLE
fix: module resolution checks in monorepos

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -146,6 +146,12 @@ module.exports = {
         ][1].devDependencies.map((glob) => glob.replace('js,jsx', 'js,jsx,ts,tsx')),
       },
     ],
+
+    /* Using TypeScript makes it safe enough to disable the checks below */
+
+    // Disable ESLint-based module resolution check for improved monorepo support
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
+    'import/no-unresolved': 'off',
   },
   overrides: [
     {

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -146,12 +146,6 @@ module.exports = {
         ][1].devDependencies.map((glob) => glob.replace('js,jsx', 'js,jsx,ts,tsx')),
       },
     ],
-
-    /* Using TypeScript makes it safe enough to disable the checks below */
-
-    // Disable ESLint-based module resolution check for improved monorepo support
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
-    'import/no-unresolved': 'off',
   },
   overrides: [
     {
@@ -161,6 +155,12 @@ module.exports = {
         // https://github.com/iamturns/eslint-config-airbnb-typescript/issues/50
         // This will be caught by TypeScript compiler if `strictNullChecks` (or `strict`) is enabled
         'no-undef': 'off',
+
+        /* Using TypeScript makes it safe enough to disable the checks below */
+
+        // Disable ESLint-based module resolution check for improved monorepo support
+        // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md
+        'import/no-unresolved': 'off',
       },
     },
   ],


### PR DESCRIPTION
As TypeScript already checks for the existence of modules, the [`import/no-unresolved`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-unresolved.md) rule is redundant.