### PR TITLE
fix: remove references to deprecated camelcase rule

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -31,7 +31,25 @@ module.exports = {
     // Replace Airbnb 'camelcase' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/camelcase.md
     camelcase: 'off',
-    '@typescript-eslint/camelcase': baseStyleRules.camelcase,
+    '@typescript-eslint/naming-convention': [
+      'error',
+      {
+        selector: 'default',
+        format: ['camelCase'],
+      },
+      {
+        selector: 'variable',
+        format: ['camelCase', 'UPPER_CASE'],
+      },
+      {
+        selector: 'parameter',
+        format: ['camelCase'],
+      },
+      {
+        selector: 'typeLike',
+        format: ['PascalCase'],
+      },
+    ], // typescript-eslint camelcase rule has now been removed https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/camelcase.md
 
     // Replace Airbnb 'comma-spacing' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/comma-spacing.md


### PR DESCRIPTION
Typescript eslint camelcase rule has now been removed in favour of the new naming-convention rule.
This change removes the reference to camelcase and replaces it with an equivalent naming-convention
rule.

fix #95