### PR TITLE
fix: Allow PascalCase variables for React components

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -38,15 +38,15 @@ module.exports = {
         selector: 'default',
         format: ['camelCase'],
       },
+      // Allow PascalCase variables for React components, and UPPER_CASE variables for 23.10
+      {
+        selector: 'variable',
+        format: ['camelCase', 'PascalCase', 'UPPER_CASE'],
+      },
       // Airbnb recommends PascalCase for classes (23.3), and although Airbnb does not make TypeScript recommendations, we are assuming this rule would similarly apply to anything "type like", including interfaces, type aliases, and enums.
       {
         selector: 'typeLike',
         format: ['PascalCase'],
-      },
-      // Allow UPPER_CASE for variables to cater for 23.10
-      {
-        selector: 'variable',
-        format: ['camelCase', 'UPPER_CASE'],
       },
       // Allow any naming convention for properties, because (1) Airbnb does not specify any naming conventions for properties (2) The `camelcase` rule specifically disables checking properties: https://github.com/airbnb/javascript/blob/06b3ab11d9a443ff46f052dd00375e271e5146e6/packages/eslint-config-airbnb-base/rules/style.js#L24
       {


### PR DESCRIPTION
Fixes #101 
