### PR TITLE
Update all dependencies to latest versions solving peer dependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,25 +23,25 @@
     "validate": "npm run lint"
   },
   "dependencies": {
-    "@typescript-eslint/parser": "^3.1.0",
-    "eslint-config-airbnb": "^18.1.0",
-    "eslint-config-airbnb-base": "^14.1.0"
+    "@typescript-eslint/parser": "^3.6.0",
+    "eslint-config-airbnb": "^18.2.0",
+    "eslint-config-airbnb-base": "^14.2.0"
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.1.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "3.1.0",
+    "@typescript-eslint/eslint-plugin": "3.6.0",
     "doctoc": "1.4.0",
-    "eslint": "6.8.0",
+    "eslint": "7.4.0",
     "eslint-config-prettier": "6.11.0",
-    "eslint-plugin-import": "2.20.2",
+    "eslint-plugin-import": "2.22.0",
     "husky": "4.2.5",
-    "lint-staged": "10.2.8",
+    "lint-staged": "10.2.11",
     "npm-run-all": "4.1.5",
     "prettier": "2.0.5",
     "prettier-package-json": "2.1.3",
-    "typescript": "3.9.3"
+    "typescript": "3.9.6"
   },
   "keywords": [
     "airbnb",


### PR DESCRIPTION
I have explicitly updated everything to the latest versions. Before this update I had these errors using `pnpm install`:
```
lint-staged: listr2@2.2.0 requires a peer of enquirer@>= 2.3.0 < 3 but none was installed.
 WARN  eslint-config-airbnb: eslint-config-airbnb-base@14.2.0 requires a peer of eslint-plugin-import@^2.21.2 but version 2.20.2 was installed.
 WARN  eslint-config-airbnb@18.2.0 requires a peer of eslint-plugin-import@^2.21.2 but version 2.20.2 was installed.
 WARN  eslint-config-airbnb-base@14.2.0 requires a peer of eslint-plugin-import@^2.21.2 but version 2.20.2 was installed.
```