### PR TITLE
fix(deps): add downstream peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,12 @@
     "eslint-config-airbnb-base": "^14.2.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.6.1"
+    "@typescript-eslint/eslint-plugin": "^3.6.1",
+    "eslint": "^5.16.0 || ^6.8.0 || ^7.2.0",
+    "eslint-plugin-import": "^2.21.2",
+    "eslint-plugin-jsx-a11y": "^6.3.0",
+    "eslint-plugin-react": "^7.20.0",
+    "eslint-plugin-react-hooks": "^4 || ^3 || ^2.3.0 || ^1.7.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "3.6.1",
@@ -55,5 +60,16 @@
     "javascript",
     "styleguide",
     "typescript"
-  ]
+  ],
+  "peerDependenciesMeta": {
+    "eslint-plugin-jsx-a11y": {
+      "optional": true
+    },
+    "eslint-plugin-react": {
+      "optional": true
+    },
+    "eslint-plugin-react-hooks": {
+      "optional": true
+    }
+  }
 }


### PR DESCRIPTION
Fixes #6 by adding downstream peer dependencies to this package (we add
the React specific dependencies as optional).

This also enables Yarn v2 support (which requires upstream packages to
include their dependency's peer dependencies).