### PR TITLE
Disable no new func

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -105,9 +105,10 @@ module.exports = {
     'no-extra-semi': 'off',
     '@typescript-eslint/no-extra-semi': baseErrorsRules['no-extra-semi'],
 
-    // Replace Airbnb 'no-implied-eval' rule with '@typescript-eslint' version
+    // Replace Airbnb 'no-implied-eval' and 'no-new-func' rules with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-implied-eval.md
     'no-implied-eval': 'off',
+    'no-new-func': 'off',
     '@typescript-eslint/no-implied-eval': baseBestPracticesRules['no-implied-eval'],
 
     // Replace Airbnb 'no-magic-numbers' rule with '@typescript-eslint' version


### PR DESCRIPTION
[typescript-eslint's no implied eval](https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-implied-eval.md) merges two ESLint rules: [no-implied-eval](https://eslint.org/docs/rules/no-implied-eval) and [no-new-func](https://eslint.org/docs/rules/no-new-func) (and also blocks setImmediate, which i couldn't find a vanilla ESLint equivalent). Currently, using the following code outputs redundant errors:

```ts
/*
Implied eval. Do not use the Function constructor to create functions. eslint(@typescript-eslint/no-implied-eval)
The Function constructor is eval. eslint(no-new-func)
*/
const x = new Function('a', 'b', 'return a + b');
```