### PR TITLE
feat: implement 'plugin:import/typescript' rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,12 @@
 module.exports = {
   extends: ['eslint-config-airbnb', './lib/shared'].map(require.resolve),
   settings: {
-    // Append 'ts' and 'tsx' extensions to Airbnb 'import/resolver' setting
+    // Append 'ts' extensions to Airbnb 'import/resolver' setting
     'import/resolver': {
       node: {
-        extensions: ['.js', '.ts', '.jsx', '.tsx', '.json'],
+        extensions: ['.js', '.jsx', '.json', '.ts', '.tsx', '.d.ts'],
       },
     },
-    // Append 'ts' and 'tsx' extensions to Airbnb 'import/extensions' setting
-    'import/extensions': ['.js', '.ts', '.mjs', '.jsx', '.tsx'],
   },
   rules: {
     // Append 'tsx' to Airbnb 'react/jsx-filename-extension' rule

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -25,10 +25,6 @@ module.exports = {
     'import/external-module-folders': ['node_modules', 'node_modules/@types'],
   },
   rules: {
-    // TypeScript compilation already ensures that named imports exist in the referenced module
-    // https://github.com/benmosher/eslint-plugin-import/blob/master/config/typescript.js
-    'import/named': 'off',
-
     // Replace Airbnb 'brace-style' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/brace-style.md
     'brace-style': 'off',

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -23,8 +23,6 @@ module.exports = {
     'import/extensions': ['.js', '.mjs', '.jsx', '.ts', '.tsx', '.d.ts'],
     // Resolve type definition packages
     'import/external-module-folders': ['node_modules', 'node_modules/@types'],
-    // Don't ignore 'node_modules' for improved safety
-    'import/ignore': ['\\.(coffee|scss|css|less|hbs|svg|json)$'],
   },
   rules: {
     // TypeScript compilation already ensures that named imports exist in the referenced module

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -16,13 +16,21 @@ module.exports = {
     // Append 'ts' extensions to Airbnb 'import/resolver' setting
     'import/resolver': {
       node: {
-        extensions: ['.mjs', '.js', '.ts', '.json'],
+        extensions: ['.mjs', '.js', '.json', '.ts', '.d.ts'],
       },
     },
     // Append 'ts' extensions to Airbnb 'import/extensions' setting
-    'import/extensions': ['.js', '.ts', '.mjs'],
+    'import/extensions': ['.js', '.mjs', '.jsx', '.ts', '.tsx', '.d.ts'],
+    // Resolve type definition packages
+    'import/external-module-folders': ['node_modules', 'node_modules/@types'],
+    // Don't ignore 'node_modules' for improved safety
+    'import/ignore': ['\\.(coffee|scss|css|less|hbs|svg|json)$'],
   },
   rules: {
+    // TypeScript compilation already ensures that named imports exist in the referenced module
+    // https://github.com/benmosher/eslint-plugin-import/blob/master/config/typescript.js
+    'import/named': 'off',
+
     // Replace Airbnb 'brace-style' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/brace-style.md
     'brace-style': 'off',


### PR DESCRIPTION
This PR makes configs consistent with eslint-plugin-import's [`plugin:import/typescript` rules](https://github.com/benmosher/eslint-plugin-import/blob/master/config/typescript.js).

Resolves #125.