### PR TITLE
fix: import/no-extraneous-deps in .ts config files

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -57,12 +57,15 @@ module.exports = {
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/comma-dangle.md
     // The TypeScript version also adds 3 new options, all of which should be set to the same value as the base config
     'comma-dangle': 'off',
-    '@typescript-eslint/comma-dangle': [baseStyleRules['comma-dangle'][0], {
-      ...baseStyleRules['comma-dangle'][1],
-      enums: baseStyleRules['comma-dangle'][1].arrays,
-      generics: baseStyleRules['comma-dangle'][1].arrays,
-      tuples: baseStyleRules['comma-dangle'][1].arrays,
-    }],
+    '@typescript-eslint/comma-dangle': [
+      baseStyleRules['comma-dangle'][0],
+      {
+        ...baseStyleRules['comma-dangle'][1],
+        enums: baseStyleRules['comma-dangle'][1].arrays,
+        generics: baseStyleRules['comma-dangle'][1].arrays,
+        tuples: baseStyleRules['comma-dangle'][1].arrays,
+      },
+    ],
 
     // Replace Airbnb 'comma-spacing' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/comma-spacing.md

--- a/lib/shared.js
+++ b/lib/shared.js
@@ -208,7 +208,7 @@ module.exports = {
         ...baseImportsRules['import/no-extraneous-dependencies'][1],
         devDependencies: baseImportsRules[
           'import/no-extraneous-dependencies'
-        ][1].devDependencies.map((glob) => glob.replace('js,jsx', 'js,jsx,ts,tsx')),
+        ][1].devDependencies.map((glob) => glob.replace(/\bjs(x?)\b/g, 'ts$1')),
       },
     ],
   },


### PR DESCRIPTION
Several config files such as `webpack.js` are not listed as `{js,jsx}`.

Fixes #121