### PR TITLE
chore(deps): Peer dependencies to latest major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "eslint-config-airbnb-base": "^14.2.1"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^4.29.3 || ^5.0.0",
-    "@typescript-eslint/parser": "^4.29.3 || ^5.0.0"
+    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/parser": "^5.0.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "5.3.0",


### PR DESCRIPTION
BREAKING CHANGE: Peer dependency update. Update @typescript-eslint/eslint-plugin and @typescript-eslint/parser to ^5.0.0.