### PR TITLE
Replace rules with '@typescript-eslint' version and disable React prop types rules

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -74,6 +74,11 @@ module.exports = {
     'comma-spacing': 'off',
     '@typescript-eslint/comma-spacing': baseStyleRules['comma-spacing'],
 
+    // Replace Airbnb 'default-param-last' rule with '@typescript-eslint' version
+    // https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/default-param-last.md
+    'default-param-last': 'off',
+    '@typescript-eslint/default-param-last': baseBestPracticesRules['default-param-last'],
+
     // Replace Airbnb 'dot-notation' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/dot-notation.md
     'dot-notation': 'off',
@@ -129,6 +134,11 @@ module.exports = {
     'no-implied-eval': 'off',
     'no-new-func': 'off',
     '@typescript-eslint/no-implied-eval': baseBestPracticesRules['no-implied-eval'],
+
+    // Replace Airbnb 'no-loss-of-precision' rule with '@typescript-eslint' version
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-loss-of-precision.md
+    'no-loss-of-precision': 'off',
+    '@typescript-eslint/no-loss-of-precision': baseErrorsRules['no-loss-of-precision'],
 
     // Replace Airbnb 'no-loop-func' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-loop-func.md


### PR DESCRIPTION
Replace rules with '@typescript-eslint' version (default-param-last, no-loss-of-precision) and disable React prop types rules (react/prop-types, react/default-props-match-prop-types)