### PR TITLE
Surface peer dependencies of eslint-config-airbnb-base dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   },
   "peerDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.0.0",
-    "@typescript-eslint/parser": "^5.0.0"
+    "@typescript-eslint/parser": "^5.0.0",
+    "eslint": "^7.32.0 || ^8.2.0",
+    "eslint-plugin-import": "^2.25.3"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "5.4.0",


### PR DESCRIPTION
I believe this is ok as a non-breaking change as this package pretty much implicitly requires **eslint** and **eslint-plugin-import**, right?

Fixes #274

See also: https://github.com/iamturns/eslint-config-airbnb-typescript/issues/207#issuecomment-1030420694
