### PR TITLE
fix: Enforce airbnb-base no-return-await intention

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -208,7 +208,7 @@ module.exports = {
     // Replace Airbnb 'no-return-await' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/return-await.md
     'no-return-await': 'off',
-    '@typescript-eslint/return-await': baseBestPracticesRules['no-return-await'],
+    '@typescript-eslint/return-await': [baseBestPracticesRules['no-return-await'], 'never'],
 
     // Replace Airbnb 'space-infix-ops' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/space-infix-ops.md


### PR DESCRIPTION
The value for no-return-await from airbnb was being incorrectly mapped to return-await (https://typescript-eslint.io/rules/return-await/)

This was effectively linting the opposite of what it should and forcing the code to always add await to the return instead of disallowing it.