### PR TITLE
Allow return-await in try-catch block

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -208,7 +208,7 @@ module.exports = {
     // Replace Airbnb 'no-return-await' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/return-await.md
     'no-return-await': 'off',
-    '@typescript-eslint/return-await': [baseBestPracticesRules['no-return-await'], 'never'],
+    '@typescript-eslint/return-await': [baseBestPracticesRules['no-return-await'], 'in-try-catch'],
 
     // Replace Airbnb 'space-infix-ops' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/space-infix-ops.md


### PR DESCRIPTION
The `return await` should be allowed in a try-catch block for correct async error handling behavior, for example:
```
async function doSomething() {
  try {
    return await doSomethingAsync();
  } catch (err) {
    console.log('we have an error!');
  }
}
```
Using `in-try-catch` specified in https://typescript-eslint.io/rules/return-await/#in-try-catch
Solve issue https://github.com/iamturns/eslint-config-airbnb-typescript/issues/280