### PR TITLE
Replace 'space-before-blocks' with '@typescript-eslint' version

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -162,6 +162,11 @@ module.exports = {
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': baseVariablesRules['no-shadow'],
 
+    // Replace Airbnb 'space-before-blocks' rule with '@typescript-eslint' version
+    // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/space-before-blocks.md
+    'space-before-blocks': 'off',
+    '@typescript-eslint/space-before-blocks': baseStyleRules['space-before-blocks'],
+
     // Replace Airbnb 'no-throw-literal' rule with '@typescript-eslint' version
     // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-throw-literal.md
     'no-throw-literal': 'off',


### PR DESCRIPTION
Replace airbnb [`space-before-blocks`](https://github.com/airbnb/javascript/blob/eslint-config-airbnb-v19.0.4/packages/eslint-config-airbnb-base/rules/style.js#L472) with [`@typescript-eslint/space-before-blocks`](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/space-before-blocks.md) version