### PR TITLE
docs(README.md): edit step 1 of Setup to provide a stronger, easier to read sentence for those getting started

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Enhances Airbnb's ESLint config with TypeScript support
 
 ### 1) Setup regular Airbnb config
 
-Make sure you have the regular Airbnb config setup. See [eslint-config-airbnb](https://www.npmjs.com/package/eslint-config-airbnb), or [eslint-config-airbnb-base](https://www.npmjs.com/package/eslint-config-airbnb-base) if you're not using React.
+Make sure you have the regular Airbnb config setup. If you are using React, use [eslint-config-airbnb](https://www.npmjs.com/package/eslint-config-airbnb), or if you aren't using React, use [eslint-config-airbnb-base](https://www.npmjs.com/package/eslint-config-airbnb-base).
 
 ### 2) Install dependencies (and peer dependencies)
 


### PR DESCRIPTION
Instead of suggesting softly that users 'see' one or the other base configs, I figured I could make this change to help those just getting started realize that they will need to pick the right base. 

Hopefully this might reduce the time spent researching the differences.