### PR TITLE
chore: bumped peerDependencies to reflect the use of space-before-blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Make sure you have the regular Airbnb config setup. If you are using React, use 
 
 ```bash
 npm install eslint-config-airbnb-typescript \
-            @typescript-eslint/eslint-plugin@^5.0.0 \
+            @typescript-eslint/eslint-plugin@^5.13.0 \
             @typescript-eslint/parser@^5.0.0 \
             --save-dev
 ```

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-config-airbnb-base": "^15.0.0"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.0.0",
+    "@typescript-eslint/eslint-plugin": "^5.13.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^7.32.0 || ^8.2.0",
     "eslint-plugin-import": "^2.25.3"


### PR DESCRIPTION
`space-before-blocks` is only added in [@typescript-eslint/eslint-plugin@5.13.0](https://github.com/typescript-eslint/typescript-eslint/blob/main/CHANGELOG.md#5130-2022-02-28) peerDependencies & README should be updated to reflect that.