### PR TITLE
fix: re-enable `no-unreachable`, since TS does NOT handle it by default

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -279,7 +279,6 @@ module.exports = {
         'no-setter-return': 'off',
         'no-this-before-super': 'off',
         'no-undef': 'off',
-        'no-unreachable': 'off',
         'no-unsafe-negation': 'off',
         'valid-typeof': 'off',
         // The following rules are enabled in Airbnb config, but are recommended to be disabled within TypeScript projects


### PR DESCRIPTION
Not marked as a breaking change since this was *intended* to be enabled de-facto.

Closes #347.