### PR TITLE
feat: use TS variant of `class-methods-use-this`

### DIFF
--- a/lib/shared.js
+++ b/lib/shared.js
@@ -227,6 +227,16 @@ module.exports = {
     'object-curly-spacing': 'off',
     '@typescript-eslint/object-curly-spacing': baseStyleRules['object-curly-spacing'],
 
+    // The base rule works fine with Typescript, but the Typescript version has
+    // additional options for our users.
+    'class-methods-use-this': 'off',
+    '@typescript-eslint/class-methods-use-this': [
+      baseBestPracticesRules['class-methods-use-this'][0],
+      {
+        ...baseBestPracticesRules['class-methods-use-this'][1],
+      },
+    ],
+
     // Append 'ts' and 'tsx' to Airbnb 'import/extensions' rule
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/extensions.md
     'import/extensions': [


### PR DESCRIPTION
By default, this does not deviate in behavior from the original rule. It does, however, provide users with additional configuration options to disable errors when `this` is not used in classes that implement interfaces or methods that explicitly override parent methods.

The configuration we provide has been left at the default, though, since those rules are arguably over-permissive in the pursuit of not requiring type information.

Closes #344.